### PR TITLE
Change number of classes in lfw_pair documentation

### DIFF
--- a/sklearn/datasets/_lfw.py
+++ b/sklearn/datasets/_lfw.py
@@ -393,7 +393,7 @@ def fetch_lfw_pairs(subset='train', data_home=None, funneled=True, resize=0.5,
     Download it if necessary.
 
     =================   =======================
-    Classes                                5749
+    Classes                                   2
     Samples total                         13233
     Dimensionality                         5828
     Features            real, between 0 and 255
@@ -461,7 +461,7 @@ def fetch_lfw_pairs(subset='train', data_home=None, funneled=True, resize=0.5,
             output.
         target : numpy array of shape (2200,). Shape depends on ``subset``.
             Labels associated to each pair of images.
-            The two label values being different persons or the same person.
+            The two label values being "different persons" or the "same person."
         DESCR : string
             Description of the Labeled Faces in the Wild (LFW) dataset.
 


### PR DESCRIPTION
Previous number of 5749 was actually the size of the set from which the pair of face labels were sampled. It was misleading because the task isn't to predict the label of the pair but wether or not the two faces belong to the same person, hence a binary classification task.

#### Reference Issues/PRs

Fix #16757
